### PR TITLE
Fix profile display

### DIFF
--- a/src/layout/TesterModal/index.js
+++ b/src/layout/TesterModal/index.js
@@ -13,7 +13,7 @@ const YT_OPTS = "controls=1&autoplay=1"
 export default function TesterModal() {
     const { featured, clearFeatured, current, feature } = useCohort()
     const [ media, setMedia ] = useState({ type: '', content: ''})
-    // const [ cohort, ] = useState(() => current ? current.name : featured.cohort)
+    const [ cohort, ] = useState(() => current ? current.name : featured.cohort)
     const screen = useWindowSize()
     const { pathname } = useLocation()
     const navigate = useNavigate()


### PR DESCRIPTION
One of my students pointed out that student profiles weren't loading when the relevant link was clicked.

This was due to the `cohort` variable not being recognised, because it had been commented out; this PR uncomments it, which should get the profiles working again.

I know there's a lot of development going on on this, and it might be that the profiles will be handled by a different mechanism in the near future, but I thought I'd make the PR as a potential temporary fix. It's quite likely that I'm missing key context here though, so also feel free to ignore me.